### PR TITLE
Remove unnecessary Debug requirements for types

### DIFF
--- a/src/all_equal.rs
+++ b/src/all_equal.rs
@@ -49,13 +49,11 @@ mod tests {
     use rand::distributions::Standard;
     use rand::prelude::Distribution;
     use rand::Rng;
-    use std::fmt::Debug;
 
     fn test_simd_for_type<T>()
     where
         T: rand::distributions::uniform::SampleUniform
             + PartialEq
-            + Debug
             + Copy
             + Default
             + SimdElement

--- a/src/contains.rs
+++ b/src/contains.rs
@@ -45,13 +45,11 @@ mod tests {
     use rand::prelude::Distribution;
     use rand::seq::SliceRandom;
     use rand::Rng;
-    use std::fmt::Debug;
 
     fn test_simd_for_type<T>()
     where
         T: rand::distributions::uniform::SampleUniform
             + PartialEq
-            + Debug
             + Copy
             + Default
             + SimdElement

--- a/src/eq.rs
+++ b/src/eq.rs
@@ -49,13 +49,11 @@ mod tests {
     use rand::distributions::Standard;
     use rand::prelude::Distribution;
     use rand::Rng;
-    use std::fmt::Debug;
 
     fn test_for_type<T>()
     where
         T: rand::distributions::uniform::SampleUniform
             + PartialEq
-            + Debug
             + Copy
             + Default
             + SimdElement
@@ -93,7 +91,6 @@ mod tests {
     where
         T: rand::distributions::uniform::SampleUniform
             + PartialEq
-            + Debug
             + Copy
             + Default
             + SimdElement

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -19,7 +19,7 @@ where
 // TODO REMOVE DUPLICATION?
 impl<'a, T> FilterSimd<'a, T> for slice::Iter<'a, T>
 where
-    T: SimdElement + std::cmp::PartialEq + std::cmp::PartialOrd + std::fmt::Debug + Default,
+    T: SimdElement + std::cmp::PartialEq + std::cmp::PartialOrd + Default,
     Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
 {
     fn filter_simd_lt(&self, needle: T) -> Vec<T> {


### PR DESCRIPTION
In the actual implementations, there is the requirement that the types implement Debug, and this is not needed, this forces users to derive Debug for types that might not need it, this PR passes all the tests.