### PR TITLE
Restructure criterion benchmarks into groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "simd-itertools"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "itertools 0.13.0",

--- a/benches/all_equal.rs
+++ b/benches/all_equal.rs
@@ -1,54 +1,53 @@
 #![feature(portable_simd)]
 #![feature(is_sorted)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use itertools::Itertools;
-use simd_itertools::AllEqualSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::Simd;
-use std::simd::SimdElement;
-use std::time::Duration;
+use simd_itertools::{AllEqualSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+};
 
-fn benchmark_all_equal<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
+fn benchmark_all_equal<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
     T: SimdElement + std::cmp::PartialEq,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
 {
-    let v1 = vec![T::default(); len];
+    let mut group = c.benchmark_group(format!("all-equal-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
 
-    group.bench_function(&format!("SIMD all_equal {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().all_equal_simd()))
-    });
-    group.bench_function(&format!("Scalar all_equal {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().all_equal()))
-    });
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().all_equal_simd()))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().all_equal()))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_all_equal::<u8>(c, "u8", n);
-        benchmark_all_equal::<i8>(c, "i8", n);
-        benchmark_all_equal::<u16>(c, "u16", n);
-        benchmark_all_equal::<i16>(c, "i16", n);
-        benchmark_all_equal::<u32>(c, "u32", n);
-        benchmark_all_equal::<i32>(c, "i32", n);
-        benchmark_all_equal::<u64>(c, "u64", n);
-        benchmark_all_equal::<i64>(c, "i64", n);
-        benchmark_all_equal::<f32>(c, "f32", n);
-        benchmark_all_equal::<f64>(c, "f64", n);
-        benchmark_all_equal::<isize>(c, "isize", n);
-        benchmark_all_equal::<usize>(c, "usize", n);
-    }
+    benchmark_all_equal::<u8>(c);
+    // benchmark_all_equal::<i8>(c);
+    // benchmark_all_equal::<u16>(c);
+    // benchmark_all_equal::<i16>(c, "i16", n);
+    // benchmark_all_equal::<u32>(c, "u32", n);
+    // benchmark_all_equal::<i32>(c, "i32", n);
+    // benchmark_all_equal::<u64>(c, "u64", n);
+    // benchmark_all_equal::<i64>(c, "i64", n);
+    // benchmark_all_equal::<f32>(c, "f32", n);
+    // benchmark_all_equal::<f64>(c, "f64", n);
+    // benchmark_all_equal::<isize>(c, "isize", n);
+    // benchmark_all_equal::<usize>(c, "usize", n);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/all_equal.rs
+++ b/benches/all_equal.rs
@@ -37,17 +37,17 @@ where
 
 fn criterion_benchmark(c: &mut Criterion) {
     benchmark_all_equal::<u8>(c);
-    // benchmark_all_equal::<i8>(c);
-    // benchmark_all_equal::<u16>(c);
-    // benchmark_all_equal::<i16>(c, "i16", n);
-    // benchmark_all_equal::<u32>(c, "u32", n);
-    // benchmark_all_equal::<i32>(c, "i32", n);
-    // benchmark_all_equal::<u64>(c, "u64", n);
-    // benchmark_all_equal::<i64>(c, "i64", n);
-    // benchmark_all_equal::<f32>(c, "f32", n);
-    // benchmark_all_equal::<f64>(c, "f64", n);
-    // benchmark_all_equal::<isize>(c, "isize", n);
-    // benchmark_all_equal::<usize>(c, "usize", n);
+    benchmark_all_equal::<i8>(c);
+    benchmark_all_equal::<u16>(c);
+    benchmark_all_equal::<i16>(c);
+    benchmark_all_equal::<u32>(c);
+    benchmark_all_equal::<i32>(c);
+    benchmark_all_equal::<u64>(c);
+    benchmark_all_equal::<i64>(c);
+    benchmark_all_equal::<f32>(c);
+    benchmark_all_equal::<f64>(c);
+    benchmark_all_equal::<isize>(c);
+    benchmark_all_equal::<usize>(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/contains.rs
+++ b/benches/contains.rs
@@ -1,79 +1,81 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
-#![feature(sort_floats)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
+// #![feature(sort_floats)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use itertools::Itertools;
-use simd_itertools::ContainsSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use itertools::Itertools;
+// use simd_itertools::ContainsSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<i32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.try_into().unwrap();
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<i32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let needle: T = 55.try_into().unwrap();
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
 
-    group.bench_function(&format!("SIMD contains {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().contains_simd(&needle)))
-    });
-    group.bench_function(&format!("Scalar contains {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().contains(&needle)))
-    });
-}
+//     group.bench_function(&format!("SIMD contains {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().contains_simd(&needle)))
+//     });
+//     group.bench_function(&format!("Scalar contains {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().contains(&needle)))
+//     });
+// }
 
-fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<f32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let v2 = vec![T::default(); len];
-    let needle: T = 55.0.try_into().unwrap();
-    assert_eq!(v1, v2);
+// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<f32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let v2 = vec![T::default(); len];
+//     let needle: T = 55.0.try_into().unwrap();
+//     assert_eq!(v1, v2);
 
-    c.bench_function(&format!("SIMD contains {}", name), |b| {
-        b.iter(|| black_box(v1.iter().contains_simd(&needle)))
-    });
-    c.bench_function(&format!("trivial contains {}", name), |b| {
-        b.iter(|| black_box(v1.iter().contains(&needle)))
-    });
-}
+//     c.bench_function(&format!("SIMD contains {}", name), |b| {
+//         b.iter(|| black_box(v1.iter().contains_simd(&needle)))
+//     });
+//     c.bench_function(&format!("trivial contains {}", name), |b| {
+//         b.iter(|| black_box(v1.iter().contains(&needle)))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains_floats::<f32>(c, "f32", n);
-        benchmark_contains_floats::<f64>(c, "f64", n);
-    }
-}
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//         benchmark_contains_floats::<f32>(c, "f32", n);
+//         benchmark_contains_floats::<f64>(c, "f64", n);
+//     }
+// }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/contains.rs
+++ b/benches/contains.rs
@@ -1,81 +1,84 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
-// #![feature(sort_floats)]
+#![feature(portable_simd)]
+#![feature(is_sorted)]
+#![feature(sort_floats)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use itertools::Itertools;
-// use simd_itertools::ContainsSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
+use simd_itertools::{ContainsSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<i32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let needle: T = 55.try_into().unwrap();
+fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<i32>>::Error: Debug,
+{
+    let mut group = c.benchmark_group(format!("contains-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = 55.try_into().unwrap();
 
-//     group.bench_function(&format!("SIMD contains {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().contains_simd(&needle)))
-//     });
-//     group.bench_function(&format!("Scalar contains {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().contains(&needle)))
-//     });
-// }
+        group.throughput(Throughput::Elements(len as u64));
 
-// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<f32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let v2 = vec![T::default(); len];
-//     let needle: T = 55.0.try_into().unwrap();
-//     assert_eq!(v1, v2);
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().contains_simd(&needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().contains(&needle)))
+        });
 
-//     c.bench_function(&format!("SIMD contains {}", name), |b| {
-//         b.iter(|| black_box(v1.iter().contains_simd(&needle)))
-//     });
-//     c.bench_function(&format!("trivial contains {}", name), |b| {
-//         b.iter(|| black_box(v1.iter().contains(&needle)))
-//     });
-// }
+        len *= 10;
+    }
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//         benchmark_contains_floats::<f32>(c, "f32", n);
-//         benchmark_contains_floats::<f64>(c, "f64", n);
-//     }
-// }
+    group.finish();
+}
 
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
+fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<f32>>::Error: Debug,
+{
+    let mut group = c.benchmark_group(format!("contains-float-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-fn main() {}
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let v2 = vec![T::default(); len];
+        let needle: T = 55.0.try_into().unwrap();
+        assert_eq!(v1, v2);
+
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().contains_simd(&needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().contains(&needle)))
+        });
+    }
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_contains::<u8>(c);
+    benchmark_contains::<i8>(c);
+    benchmark_contains::<u16>(c);
+    benchmark_contains::<i16>(c);
+    benchmark_contains::<u32>(c);
+    benchmark_contains::<i32>(c);
+    benchmark_contains::<u64>(c);
+    benchmark_contains::<i64>(c);
+    benchmark_contains::<isize>(c);
+    benchmark_contains::<usize>(c);
+    benchmark_contains_floats::<f32>(c);
+    benchmark_contains_floats::<f64>(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/contains.rs
+++ b/benches/contains.rs
@@ -61,6 +61,8 @@ where
         group.bench_function(BenchmarkId::new("Scalar", len), |b| {
             b.iter(|| black_box(v1.iter().contains(&needle)))
         });
+
+        len *= 10;
     }
     group.finish();
 }

--- a/benches/eq.rs
+++ b/benches/eq.rs
@@ -1,54 +1,52 @@
-// #![feature(portable_simd)]
+#![feature(portable_simd)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::EqSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use simd_itertools::EqSimd;
+use simd_itertools::SIMD_LEN;
+use std::fmt::Debug;
+use std::simd::prelude::SimdPartialEq;
+use std::simd::Mask;
+use std::simd::{Simd, SimdElement};
+use std::time::Duration;
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-// {
-//     let v1 = black_box(vec![T::default(); len]);
-//     let v2 = black_box(vec![T::default(); len]);
+fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+    _c: &mut Criterion,
+    name: &str,
+    len: usize,
+) where
+    T: SimdElement + std::cmp::PartialEq,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+{
+    let v1 = black_box(vec![T::default(); len]);
+    let v2 = black_box(vec![T::default(); len]);
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
+    let mut group = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
 
-//     group.bench_function(&format!("SIMD eq {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
-//     });
-//     group.bench_function(&format!("Scalar eq {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().eq(&v2)))
-//     });
-// }
+    group.bench_function(&format!("SIMD eq {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
+    });
+    group.bench_function(&format!("Scalar eq {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().eq(&v2)))
+    });
+}
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//         benchmark_contains::<f32>(c, "f32", n);
-//         benchmark_contains::<f64>(c, "f64", n);
-//     }
-// }
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
-
-fn main() {}
+fn criterion_benchmark(c: &mut Criterion) {
+    for n in (0..200).map(|x| x * 10) {
+        benchmark_contains::<u8>(c, "u8", n);
+        benchmark_contains::<i8>(c, "i8", n);
+        benchmark_contains::<u16>(c, "u16", n);
+        benchmark_contains::<i16>(c, "i16", n);
+        benchmark_contains::<u32>(c, "u32", n);
+        benchmark_contains::<i32>(c, "i32", n);
+        benchmark_contains::<u64>(c, "u64", n);
+        benchmark_contains::<i64>(c, "i64", n);
+        benchmark_contains::<isize>(c, "isize", n);
+        benchmark_contains::<usize>(c, "usize", n);
+        benchmark_contains::<f32>(c, "f32", n);
+        benchmark_contains::<f64>(c, "f64", n);
+    }
+}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/eq.rs
+++ b/benches/eq.rs
@@ -1,52 +1,54 @@
-#![feature(portable_simd)]
+// #![feature(portable_simd)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::EqSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::EqSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-{
-    let v1 = black_box(vec![T::default(); len]);
-    let v2 = black_box(vec![T::default(); len]);
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+// {
+//     let v1 = black_box(vec![T::default(); len]);
+//     let v2 = black_box(vec![T::default(); len]);
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
 
-    group.bench_function(&format!("SIMD eq {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
-    });
-    group.bench_function(&format!("Scalar eq {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().eq(&v2)))
-    });
-}
+//     group.bench_function(&format!("SIMD eq {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
+//     });
+//     group.bench_function(&format!("Scalar eq {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().eq(&v2)))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains::<f32>(c, "f32", n);
-        benchmark_contains::<f64>(c, "f64", n);
-    }
-}
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//         benchmark_contains::<f32>(c, "f32", n);
+//         benchmark_contains::<f64>(c, "f64", n);
+//     }
+// }
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/eq.rs
+++ b/benches/eq.rs
@@ -12,7 +12,7 @@ where
     T: SimdElement + std::cmp::PartialEq,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
 {
-    let mut group = c.benchmark_group(format!("contains-{}", std::any::type_name::<T>()));
+    let mut group = c.benchmark_group(format!("eq-{}", std::any::type_name::<T>()));
     let mut len = 1;
 
     while len < (1 << 11) {

--- a/benches/eq.rs
+++ b/benches/eq.rs
@@ -1,52 +1,53 @@
 #![feature(portable_simd)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::EqSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use simd_itertools::{EqSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+};
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
+fn benchmark_eq<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
     T: SimdElement + std::cmp::PartialEq,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
 {
-    let v1 = black_box(vec![T::default(); len]);
-    let v2 = black_box(vec![T::default(); len]);
+    let mut group = c.benchmark_group(format!("contains-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+    while len < (1 << 11) {
+        let v1 = black_box(vec![T::default(); len]);
+        let v2 = black_box(vec![T::default(); len]);
 
-    group.bench_function(&format!("SIMD eq {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
-    });
-    group.bench_function(&format!("Scalar eq {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().eq(&v2)))
-    });
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().eq_simd(&v2.iter())))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().eq(&v2)))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains::<f32>(c, "f32", n);
-        benchmark_contains::<f64>(c, "f64", n);
-    }
+    benchmark_eq::<u8>(c);
+    benchmark_eq::<i8>(c);
+    benchmark_eq::<u16>(c);
+    benchmark_eq::<i16>(c);
+    benchmark_eq::<u32>(c);
+    benchmark_eq::<i32>(c);
+    benchmark_eq::<u64>(c);
+    benchmark_eq::<i64>(c);
+    benchmark_eq::<isize>(c);
+    benchmark_eq::<usize>(c);
+    benchmark_eq::<f32>(c);
+    benchmark_eq::<f64>(c);
 }
+
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);

--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -1,57 +1,55 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
-// #![feature(sort_floats)]
+#![feature(portable_simd)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::FilterSimd;
-// use std::fmt::Debug;
-// use std::simd::cmp::SimdPartialOrd;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use simd_itertools::FilterSimd;
+use std::{
+    fmt::Debug,
+    simd::{cmp::SimdPartialOrd, Mask, Simd, SimdElement},
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug + PartialOrd,
-//     Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
-//     <T as TryFrom<i32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let needle: T = 55.try_into().unwrap();
+fn benchmark_filter<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug + PartialOrd,
+    Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
+    <T as TryFrom<i32>>::Error: Debug,
+{
+    let mut group = c.benchmark_group(format!("all-equal-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD filter {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().filter_simd_lt(needle)))
-//     });
-//     group.bench_function(&format!("Scalar filter {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().filter(|x| **x < needle)))
-//     });
-// }
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = 55.try_into().unwrap();
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//     }
-// }
+        group.throughput(Throughput::Elements(len as u64));
 
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().filter_simd_lt(needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().filter(|x| **x < needle)))
+        });
 
-fn main() {}
+        len *= 10;
+    }
+
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_filter::<u8>(c);
+    benchmark_filter::<u16>(c);
+    benchmark_filter::<u32>(c);
+    benchmark_filter::<u64>(c);
+    benchmark_filter::<u8>(c);
+    benchmark_filter::<i8>(c);
+    benchmark_filter::<u16>(c);
+    benchmark_filter::<i16>(c);
+    benchmark_filter::<i32>(c);
+    benchmark_filter::<u64>(c);
+    benchmark_filter::<i64>(c);
+    benchmark_filter::<isize>(c);
+    benchmark_filter::<usize>(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -1,55 +1,57 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
-#![feature(sort_floats)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
+// #![feature(sort_floats)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::FilterSimd;
-use std::fmt::Debug;
-use std::simd::cmp::SimdPartialOrd;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::FilterSimd;
+// use std::fmt::Debug;
+// use std::simd::cmp::SimdPartialOrd;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug + PartialOrd,
-    Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
-    <T as TryFrom<i32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.try_into().unwrap();
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug + PartialOrd,
+//     Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
+//     <T as TryFrom<i32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let needle: T = 55.try_into().unwrap();
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD filter {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().filter_simd_lt(needle)))
-    });
-    group.bench_function(&format!("Scalar filter {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().filter(|x| **x < needle)))
-    });
-}
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD filter {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().filter_simd_lt(needle)))
+//     });
+//     group.bench_function(&format!("Scalar filter {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().filter(|x| **x < needle)))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-    }
-}
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//     }
+// }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -13,7 +13,7 @@ where
     Simd<T, 8>: SimdPartialOrd<Mask = Mask<T::Mask, 8>>,
     <T as TryFrom<i32>>::Error: Debug,
 {
-    let mut group = c.benchmark_group(format!("all-equal-{}", std::any::type_name::<T>()));
+    let mut group = c.benchmark_group(format!("filter-{}", std::any::type_name::<T>()));
     let mut len = 1;
 
     while len < (1 << 11) {

--- a/benches/find.rs
+++ b/benches/find.rs
@@ -1,82 +1,84 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
-// #![feature(sort_floats)]
+#![feature(portable_simd)]
+#![feature(is_sorted)]
+#![feature(sort_floats)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::FindSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use simd_itertools::{FindSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<i32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let needle: T = 55.try_into().unwrap();
+fn benchmark_find<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<i32>>::Error: Debug,
+{
+    let mut group = c.benchmark_group(format!("find-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD find {}@{}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().find_simd(needle)))
-//     });
-//     group.bench_function(&format!("Scalar find {}@{}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
-//     });
-// }
-// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<f32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let v2 = vec![T::default(); len];
-//     let needle: T = 55.0.try_into().unwrap();
-//     assert_eq!(v1, v2);
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = 55.try_into().unwrap();
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
+        group.throughput(Throughput::Elements(len as u64));
 
-//     group.bench_function(&format!("SIMD find {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().find_simd(needle)))
-//     });
-//     group.bench_function(&format!("Scalar find {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
-//     });
-// }
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().find_simd(needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
+        });
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//         benchmark_contains_floats::<f32>(c, "f32", n);
-//         benchmark_contains_floats::<f64>(c, "f64", n);
-//     }
-// }
+        len *= 10;
+    }
 
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
+    group.finish();
+}
 
-fn main() {}
+fn benchmark_find_float<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<f32>>::Error: Debug,
+{
+    let mut group = c.benchmark_group(format!("find-float-{}", std::any::type_name::<T>()));
+    let mut len = 1;
+
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = (55.0).try_into().unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().find_simd(needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_find::<u8>(c);
+    benchmark_find::<i8>(c);
+    benchmark_find::<u16>(c);
+    benchmark_find::<i16>(c);
+    benchmark_find::<u32>(c);
+    benchmark_find::<i32>(c);
+    benchmark_find::<u64>(c);
+    benchmark_find::<i64>(c);
+    benchmark_find::<isize>(c);
+    benchmark_find::<usize>(c);
+    benchmark_find_float::<f32>(c);
+    benchmark_find_float::<f64>(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/find.rs
+++ b/benches/find.rs
@@ -1,80 +1,82 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
-#![feature(sort_floats)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
+// #![feature(sort_floats)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::FindSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::FindSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<i32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.try_into().unwrap();
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<i32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let needle: T = 55.try_into().unwrap();
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD find {}@{}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().find_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar find {}@{}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
-    });
-}
-fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<f32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let v2 = vec![T::default(); len];
-    let needle: T = 55.0.try_into().unwrap();
-    assert_eq!(v1, v2);
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD find {}@{}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().find_simd(needle)))
+//     });
+//     group.bench_function(&format!("Scalar find {}@{}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
+//     });
+// }
+// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<f32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let v2 = vec![T::default(); len];
+//     let needle: T = 55.0.try_into().unwrap();
+//     assert_eq!(v1, v2);
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
 
-    group.bench_function(&format!("SIMD find {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().find_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar find {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
-    });
-}
+//     group.bench_function(&format!("SIMD find {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().find_simd(needle)))
+//     });
+//     group.bench_function(&format!("Scalar find {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().find(|x| **x == needle)))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains_floats::<f32>(c, "f32", n);
-        benchmark_contains_floats::<f64>(c, "f64", n);
-    }
-}
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//         benchmark_contains_floats::<f32>(c, "f32", n);
+//         benchmark_contains_floats::<f64>(c, "f64", n);
+//     }
+// }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/is_sorted.rs
+++ b/benches/is_sorted.rs
@@ -1,56 +1,53 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
+#![feature(portable_simd)]
+#![feature(is_sorted)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::IsSortedSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialOrd;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use simd_itertools::{IsSortedSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialOrd, Mask, Simd, SimdElement},
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + Debug + std::cmp::PartialOrd,
-//     Simd<T, SIMD_LEN>: SimdPartialOrd<Mask = Mask<T::Mask, SIMD_LEN>>,
-// {
-//     let v1 = vec![T::default(); len];
-//     let v2 = vec![T::default(); len];
-//     assert_eq!(v1, v2);
+fn benchmark_is_sorted<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + Debug + std::cmp::PartialOrd,
+    Simd<T, SIMD_LEN>: SimdPartialOrd<Mask = Mask<T::Mask, SIMD_LEN>>,
+{
+    let mut group = c.benchmark_group(format!("is-sorted-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD is_sorted {} {}", name, len), |b| {
-//         b.iter(|| black_box(black_box(&v1).iter().is_sorted_simd()))
-//     });
-//     group.bench_function(&format!("Scalar is_sorted {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().is_sorted()))
-//     });
-// }
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//         benchmark_contains::<f32>(c, "f32", n);
-//         benchmark_contains::<f64>(c, "f64", n);
-//     }
-// }
+        group.throughput(Throughput::Elements(len as u64));
 
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().is_sorted_simd()))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().is_sorted()))
+        });
 
-fn main() {}
+        len *= 10;
+    }
+
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_is_sorted::<u8>(c);
+    benchmark_is_sorted::<i8>(c);
+    benchmark_is_sorted::<u16>(c);
+    benchmark_is_sorted::<i16>(c);
+    benchmark_is_sorted::<u32>(c);
+    benchmark_is_sorted::<i32>(c);
+    benchmark_is_sorted::<u64>(c);
+    benchmark_is_sorted::<i64>(c);
+    benchmark_is_sorted::<isize>(c);
+    benchmark_is_sorted::<usize>(c);
+    benchmark_is_sorted::<f32>(c);
+    benchmark_is_sorted::<f64>(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/is_sorted.rs
+++ b/benches/is_sorted.rs
@@ -1,54 +1,56 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::IsSortedSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialOrd;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::IsSortedSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialOrd;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + Debug + std::cmp::PartialOrd,
-    Simd<T, SIMD_LEN>: SimdPartialOrd<Mask = Mask<T::Mask, SIMD_LEN>>,
-{
-    let v1 = vec![T::default(); len];
-    let v2 = vec![T::default(); len];
-    assert_eq!(v1, v2);
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + Debug + std::cmp::PartialOrd,
+//     Simd<T, SIMD_LEN>: SimdPartialOrd<Mask = Mask<T::Mask, SIMD_LEN>>,
+// {
+//     let v1 = vec![T::default(); len];
+//     let v2 = vec![T::default(); len];
+//     assert_eq!(v1, v2);
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD is_sorted {} {}", name, len), |b| {
-        b.iter(|| black_box(black_box(&v1).iter().is_sorted_simd()))
-    });
-    group.bench_function(&format!("Scalar is_sorted {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().is_sorted()))
-    });
-}
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD is_sorted {} {}", name, len), |b| {
+//         b.iter(|| black_box(black_box(&v1).iter().is_sorted_simd()))
+//     });
+//     group.bench_function(&format!("Scalar is_sorted {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().is_sorted()))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains::<f32>(c, "f32", n);
-        benchmark_contains::<f64>(c, "f64", n);
-    }
-}
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//         benchmark_contains::<f32>(c, "f32", n);
+//         benchmark_contains::<f64>(c, "f64", n);
+//     }
+// }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/max.rs
+++ b/benches/max.rs
@@ -1,49 +1,51 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::MaxSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::MaxSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-{
-    let v1 = black_box(vec![T::default(); len]);
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+// {
+//     let v1 = black_box(vec![T::default(); len]);
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD max {} {}", name, len), |b| {
-        b.iter(|| black_box(black_box(&v1).iter().max_simd()))
-    });
-    group.bench_function(&format!("Scalar max {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().max()))
-    });
-}
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD max {} {}", name, len), |b| {
+//         b.iter(|| black_box(black_box(&v1).iter().max_simd()))
+//     });
+//     group.bench_function(&format!("Scalar max {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().max()))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-    }
-}
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//     }
+// }
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/max.rs
+++ b/benches/max.rs
@@ -35,18 +35,16 @@ where
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_max::<u8>(c);
-        benchmark_max::<i8>(c);
-        benchmark_max::<u16>(c);
-        benchmark_max::<i16>(c);
-        benchmark_max::<u32>(c);
-        benchmark_max::<i32>(c);
-        benchmark_max::<u64>(c);
-        benchmark_max::<i64>(c);
-        benchmark_max::<isize>(c);
-        benchmark_max::<usize>(c);
-    }
+    benchmark_max::<u8>(c);
+    benchmark_max::<i8>(c);
+    benchmark_max::<u16>(c);
+    benchmark_max::<i16>(c);
+    benchmark_max::<u32>(c);
+    benchmark_max::<i32>(c);
+    benchmark_max::<u64>(c);
+    benchmark_max::<i64>(c);
+    benchmark_max::<isize>(c);
+    benchmark_max::<usize>(c);
 }
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);

--- a/benches/max.rs
+++ b/benches/max.rs
@@ -1,51 +1,52 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
+#![feature(portable_simd)]
+#![feature(is_sorted)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::MaxSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use simd_itertools::{MaxSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-// {
-//     let v1 = black_box(vec![T::default(); len]);
+fn benchmark_max<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
+    T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+{
+    let mut group = c.benchmark_group(format!("max-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD max {} {}", name, len), |b| {
-//         b.iter(|| black_box(black_box(&v1).iter().max_simd()))
-//     });
-//     group.bench_function(&format!("Scalar max {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().max()))
-//     });
-// }
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//     }
-// }
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
+        group.throughput(Throughput::Elements(len as u64));
 
-fn main() {}
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().max_simd()))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().max()))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    for n in (0..200).map(|x| x * 10) {
+        benchmark_max::<u8>(c);
+        benchmark_max::<i8>(c);
+        benchmark_max::<u16>(c);
+        benchmark_max::<i16>(c);
+        benchmark_max::<u32>(c);
+        benchmark_max::<i32>(c);
+        benchmark_max::<u64>(c);
+        benchmark_max::<i64>(c);
+        benchmark_max::<isize>(c);
+        benchmark_max::<usize>(c);
+    }
+}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/min.rs
+++ b/benches/min.rs
@@ -1,50 +1,47 @@
-// #![feature(portable_simd)]
+#![feature(portable_simd)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::MinSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use simd_itertools::{MinSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+    time::Duration,
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-// {
-//     let v1 = black_box(vec![T::default(); len]);
+fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+    _c: &mut Criterion,
+    name: &str,
+    len: usize,
+) where
+    T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+{
+    let v1 = black_box(vec![T::default(); len]);
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD min {} {}", name, len), |b| {
-//         b.iter(|| black_box(black_box(&v1).iter().min_simd()))
-//     });
-//     group.bench_function(&format!("Scalar min {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().min()))
-//     });
-// }
+    let mut group = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
+    group.bench_function(&format!("SIMD min {} {}", name, len), |b| {
+        b.iter(|| black_box(black_box(&v1).iter().min_simd()))
+    });
+    group.bench_function(&format!("Scalar min {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().min()))
+    });
+}
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//     }
-// }
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
-
-fn main() {}
+fn criterion_benchmark(c: &mut Criterion) {
+    for n in (0..200).map(|x| x * 10) {
+        benchmark_contains::<u8>(c, "u8", n);
+        benchmark_contains::<i8>(c, "i8", n);
+        benchmark_contains::<u16>(c, "u16", n);
+        benchmark_contains::<i16>(c, "i16", n);
+        benchmark_contains::<u32>(c, "u32", n);
+        benchmark_contains::<i32>(c, "i32", n);
+        benchmark_contains::<u64>(c, "u64", n);
+        benchmark_contains::<i64>(c, "i64", n);
+        benchmark_contains::<isize>(c, "isize", n);
+        benchmark_contains::<usize>(c, "usize", n);
+    }
+}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/min.rs
+++ b/benches/min.rs
@@ -1,47 +1,49 @@
 #![feature(portable_simd)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use simd_itertools::{MinSimd, SIMD_LEN};
 use std::{
     fmt::Debug,
     simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
-    time::Duration,
 };
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
+fn benchmark_min<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
 {
-    let v1 = black_box(vec![T::default(); len]);
+    let mut group = c.benchmark_group(format!("max-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD min {} {}", name, len), |b| {
-        b.iter(|| black_box(black_box(&v1).iter().min_simd()))
-    });
-    group.bench_function(&format!("Scalar min {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().min()))
-    });
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().min_simd()))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().min()))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-    }
+    benchmark_min::<u8>(c);
+    benchmark_min::<i8>(c);
+    benchmark_min::<u16>(c);
+    benchmark_min::<i16>(c);
+    benchmark_min::<u32>(c);
+    benchmark_min::<i32>(c);
+    benchmark_min::<u64>(c);
+    benchmark_min::<i64>(c);
+    benchmark_min::<isize>(c);
+    benchmark_min::<usize>(c);
 }
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);

--- a/benches/min.rs
+++ b/benches/min.rs
@@ -1,48 +1,50 @@
-#![feature(portable_simd)]
+// #![feature(portable_simd)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::MinSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::MinSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-{
-    let v1 = black_box(vec![T::default(); len]);
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+// {
+//     let v1 = black_box(vec![T::default(); len]);
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD min {} {}", name, len), |b| {
-        b.iter(|| black_box(black_box(&v1).iter().min_simd()))
-    });
-    group.bench_function(&format!("Scalar min {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().min()))
-    });
-}
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD min {} {}", name, len), |b| {
+//         b.iter(|| black_box(black_box(&v1).iter().min_simd()))
+//     });
+//     group.bench_function(&format!("Scalar min {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().min()))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-    }
-}
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//     }
+// }
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/min.rs
+++ b/benches/min.rs
@@ -12,7 +12,7 @@ where
     T: SimdElement + std::cmp::PartialEq + std::cmp::Ord,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
 {
-    let mut group = c.benchmark_group(format!("max-{}", std::any::type_name::<T>()));
+    let mut group = c.benchmark_group(format!("min-{}", std::any::type_name::<T>()));
     let mut len = 1;
 
     while len < (1 << 11) {

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -66,22 +66,20 @@ where
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_position::<u8>(c);
-        benchmark_position::<u64>(c);
-        benchmark_position::<u32>(c);
-        benchmark_position::<u8>(c);
-        benchmark_position::<i8>(c);
-        benchmark_position::<u16>(c);
-        benchmark_position::<i16>(c);
-        benchmark_position::<i32>(c);
-        benchmark_position::<u64>(c);
-        benchmark_position::<i64>(c);
-        benchmark_position::<isize>(c);
-        benchmark_position::<usize>(c);
-        benchmark_position_floats::<f32>(c);
-        benchmark_position_floats::<f64>(c);
-    }
+    benchmark_position::<u8>(c);
+    benchmark_position::<u64>(c);
+    benchmark_position::<u32>(c);
+    benchmark_position::<u8>(c);
+    benchmark_position::<i8>(c);
+    benchmark_position::<u16>(c);
+    benchmark_position::<i16>(c);
+    benchmark_position::<i32>(c);
+    benchmark_position::<u64>(c);
+    benchmark_position::<i64>(c);
+    benchmark_position::<isize>(c);
+    benchmark_position::<usize>(c);
+    benchmark_position_floats::<f32>(c);
+    benchmark_position_floats::<f64>(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -15,7 +15,7 @@ where
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
     <T as TryFrom<i32>>::Error: Debug,
 {
-    let mut group = c.benchmark_group(format!("max-{}", std::any::type_name::<T>()));
+    let mut group = c.benchmark_group(format!("position-{}", std::any::type_name::<T>()));
     let mut len = 1;
 
     while len < (1 << 11) {
@@ -36,46 +36,51 @@ where
 
     group.finish();
 }
-fn benchmark_position_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
+
+fn benchmark_position_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
     <T as TryFrom<f32>>::Error: Debug,
 {
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.0.try_into().unwrap();
+    let mut group = c.benchmark_group(format!("position-floats-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = (55.0).try_into().unwrap();
 
-    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-    });
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().position_simd(needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains_floats::<f32>(c, "f32", n);
-        benchmark_contains_floats::<f64>(c, "f64", n);
+        benchmark_position::<u8>(c);
+        benchmark_position::<u64>(c);
+        benchmark_position::<u32>(c);
+        benchmark_position::<u8>(c);
+        benchmark_position::<i8>(c);
+        benchmark_position::<u16>(c);
+        benchmark_position::<i16>(c);
+        benchmark_position::<i32>(c);
+        benchmark_position::<u64>(c);
+        benchmark_position::<i64>(c);
+        benchmark_position::<isize>(c);
+        benchmark_position::<usize>(c);
+        benchmark_position_floats::<f32>(c);
+        benchmark_position_floats::<f64>(c);
     }
 }
 

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -2,37 +2,41 @@
 #![feature(is_sorted)]
 #![feature(sort_floats)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use simd_itertools::{PositionSimd, SIMD_LEN};
 use std::{
     fmt::Debug,
     simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
-    time::Duration,
 };
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
+fn benchmark_position<'a, T: 'static + Copy + PartialEq + Default + Debug>(c: &mut Criterion)
+where
     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
     <T as TryFrom<i32>>::Error: Debug,
 {
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.try_into().unwrap();
+    let mut group = c.benchmark_group(format!("max-{}", std::any::type_name::<T>()));
+    let mut len = 1;
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-    });
+    while len < (1 << 11) {
+        let v1 = vec![T::default(); len];
+        let needle: T = 55.try_into().unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+
+        group.bench_function(BenchmarkId::new("SIMD", len), |b| {
+            b.iter(|| black_box(v1.iter().position_simd(needle)))
+        });
+        group.bench_function(BenchmarkId::new("Scalar", len), |b| {
+            b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+        });
+
+        len *= 10;
+    }
+
+    group.finish();
 }
-fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+fn benchmark_position_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
     _c: &mut Criterion,
     name: &str,
     len: usize,

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -1,80 +1,82 @@
-#![feature(portable_simd)]
-#![feature(is_sorted)]
-#![feature(sort_floats)]
+// #![feature(portable_simd)]
+// #![feature(is_sorted)]
+// #![feature(sort_floats)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use simd_itertools::PositionSimd;
-use simd_itertools::SIMD_LEN;
-use std::fmt::Debug;
-use std::simd::prelude::SimdPartialEq;
-use std::simd::Mask;
-use std::simd::{Simd, SimdElement};
-use std::time::Duration;
+// use criterion::{black_box, criterion_group, criterion_main, Criterion};
+// use simd_itertools::PositionSimd;
+// use simd_itertools::SIMD_LEN;
+// use std::fmt::Debug;
+// use std::simd::prelude::SimdPartialEq;
+// use std::simd::Mask;
+// use std::simd::{Simd, SimdElement};
+// use std::time::Duration;
 
-fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<i32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.try_into().unwrap();
+// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<i32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let needle: T = 55.try_into().unwrap();
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
-    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-    });
-}
-fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-    _c: &mut Criterion,
-    name: &str,
-    len: usize,
-) where
-    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-    <T as TryFrom<f32>>::Error: Debug,
-{
-    let v1 = vec![T::default(); len];
-    let needle: T = 55.0.try_into().unwrap();
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
+//     group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().position_simd(needle)))
+//     });
+//     group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+//     });
+// }
+// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+//     _c: &mut Criterion,
+//     name: &str,
+//     len: usize,
+// ) where
+//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+//     <T as TryFrom<f32>>::Error: Debug,
+// {
+//     let v1 = vec![T::default(); len];
+//     let needle: T = 55.0.try_into().unwrap();
 
-    let mut group = Criterion::default()
-        .warm_up_time(Duration::from_secs(1))
-        .measurement_time(Duration::from_secs(1));
+//     let mut group = Criterion::default()
+//         .warm_up_time(Duration::from_secs(1))
+//         .measurement_time(Duration::from_secs(1));
 
-    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position_simd(needle)))
-    });
-    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-    });
-}
+//     group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().position_simd(needle)))
+//     });
+//     group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
+//         b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+//     });
+// }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    for n in (0..200).map(|x| x * 10) {
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<u32>(c, "u32", n);
-        benchmark_contains::<u8>(c, "u8", n);
-        benchmark_contains::<i8>(c, "i8", n);
-        benchmark_contains::<u16>(c, "u16", n);
-        benchmark_contains::<i16>(c, "i16", n);
-        benchmark_contains::<i32>(c, "i32", n);
-        benchmark_contains::<u64>(c, "u64", n);
-        benchmark_contains::<i64>(c, "i64", n);
-        benchmark_contains::<isize>(c, "isize", n);
-        benchmark_contains::<usize>(c, "usize", n);
-        benchmark_contains_floats::<f32>(c, "f32", n);
-        benchmark_contains_floats::<f64>(c, "f64", n);
-    }
-}
+// fn criterion_benchmark(c: &mut Criterion) {
+//     for n in (0..200).map(|x| x * 10) {
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<u32>(c, "u32", n);
+//         benchmark_contains::<u8>(c, "u8", n);
+//         benchmark_contains::<i8>(c, "i8", n);
+//         benchmark_contains::<u16>(c, "u16", n);
+//         benchmark_contains::<i16>(c, "i16", n);
+//         benchmark_contains::<i32>(c, "i32", n);
+//         benchmark_contains::<u64>(c, "u64", n);
+//         benchmark_contains::<i64>(c, "i64", n);
+//         benchmark_contains::<isize>(c, "isize", n);
+//         benchmark_contains::<usize>(c, "usize", n);
+//         benchmark_contains_floats::<f32>(c, "f32", n);
+//         benchmark_contains_floats::<f64>(c, "f64", n);
+//     }
+// }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+
+fn main() {}

--- a/benches/position.rs
+++ b/benches/position.rs
@@ -1,82 +1,79 @@
-// #![feature(portable_simd)]
-// #![feature(is_sorted)]
-// #![feature(sort_floats)]
+#![feature(portable_simd)]
+#![feature(is_sorted)]
+#![feature(sort_floats)]
 
-// use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// use simd_itertools::PositionSimd;
-// use simd_itertools::SIMD_LEN;
-// use std::fmt::Debug;
-// use std::simd::prelude::SimdPartialEq;
-// use std::simd::Mask;
-// use std::simd::{Simd, SimdElement};
-// use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use simd_itertools::{PositionSimd, SIMD_LEN};
+use std::{
+    fmt::Debug,
+    simd::{prelude::SimdPartialEq, Mask, Simd, SimdElement},
+    time::Duration,
+};
 
-// fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<i32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let needle: T = 55.try_into().unwrap();
+fn benchmark_contains<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+    _c: &mut Criterion,
+    name: &str,
+    len: usize,
+) where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<i32> + Debug,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<i32>>::Error: Debug,
+{
+    let v1 = vec![T::default(); len];
+    let needle: T = 55.try_into().unwrap();
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
-//     group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().position_simd(needle)))
-//     });
-//     group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-//     });
-// }
-// fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
-//     _c: &mut Criterion,
-//     name: &str,
-//     len: usize,
-// ) where
-//     T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
-//     Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
-//     <T as TryFrom<f32>>::Error: Debug,
-// {
-//     let v1 = vec![T::default(); len];
-//     let needle: T = 55.0.try_into().unwrap();
+    let mut group = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
+    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().position_simd(needle)))
+    });
+    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+    });
+}
+fn benchmark_contains_floats<'a, T: 'static + Copy + PartialEq + Default + Debug>(
+    _c: &mut Criterion,
+    name: &str,
+    len: usize,
+) where
+    T: SimdElement + std::cmp::PartialEq + TryFrom<f32> + Debug + std::convert::From<f32>,
+    Simd<T, SIMD_LEN>: SimdPartialEq<Mask = Mask<T::Mask, SIMD_LEN>>,
+    <T as TryFrom<f32>>::Error: Debug,
+{
+    let v1 = vec![T::default(); len];
+    let needle: T = 55.0.try_into().unwrap();
 
-//     let mut group = Criterion::default()
-//         .warm_up_time(Duration::from_secs(1))
-//         .measurement_time(Duration::from_secs(1));
+    let mut group = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
 
-//     group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().position_simd(needle)))
-//     });
-//     group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
-//         b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
-//     });
-// }
+    group.bench_function(&format!("SIMD position {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().position_simd(needle)))
+    });
+    group.bench_function(&format!("Scalar position {} {}", name, len), |b| {
+        b.iter(|| black_box(v1.iter().position(|x| *x == needle)))
+    });
+}
 
-// fn criterion_benchmark(c: &mut Criterion) {
-//     for n in (0..200).map(|x| x * 10) {
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<u32>(c, "u32", n);
-//         benchmark_contains::<u8>(c, "u8", n);
-//         benchmark_contains::<i8>(c, "i8", n);
-//         benchmark_contains::<u16>(c, "u16", n);
-//         benchmark_contains::<i16>(c, "i16", n);
-//         benchmark_contains::<i32>(c, "i32", n);
-//         benchmark_contains::<u64>(c, "u64", n);
-//         benchmark_contains::<i64>(c, "i64", n);
-//         benchmark_contains::<isize>(c, "isize", n);
-//         benchmark_contains::<usize>(c, "usize", n);
-//         benchmark_contains_floats::<f32>(c, "f32", n);
-//         benchmark_contains_floats::<f64>(c, "f64", n);
-//     }
-// }
+fn criterion_benchmark(c: &mut Criterion) {
+    for n in (0..200).map(|x| x * 10) {
+        benchmark_contains::<u8>(c, "u8", n);
+        benchmark_contains::<u64>(c, "u64", n);
+        benchmark_contains::<u32>(c, "u32", n);
+        benchmark_contains::<u8>(c, "u8", n);
+        benchmark_contains::<i8>(c, "i8", n);
+        benchmark_contains::<u16>(c, "u16", n);
+        benchmark_contains::<i16>(c, "i16", n);
+        benchmark_contains::<i32>(c, "i32", n);
+        benchmark_contains::<u64>(c, "u64", n);
+        benchmark_contains::<i64>(c, "i64", n);
+        benchmark_contains::<isize>(c, "isize", n);
+        benchmark_contains::<usize>(c, "usize", n);
+        benchmark_contains_floats::<f32>(c, "f32", n);
+        benchmark_contains_floats::<f64>(c, "f64", n);
+    }
+}
 
-// criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
-
-fn main() {}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Hi @LaihoE,

This is just a draft PR, but the gist of it is that we can restructure the benchmarks such that `criterion` automatically produces the charts for us (please see the attached screenshot). You can see this after you run `cargo bench` and then open `target/criterion/all-equal-u8/report/index.html` in your browser.

Let me know yours thoughts. Thank you!!



<img width="1185" alt="Screenshot 2024-07-17 at 6 13 08 PM" src="https://github.com/user-attachments/assets/6d7427e5-b714-4dc4-b998-d4e1ca985ead">